### PR TITLE
fix: worktree add creates new branch instead of detached HEAD

### DIFF
--- a/worktree.go
+++ b/worktree.go
@@ -50,7 +50,9 @@ File sync is configured via .git-ctx-sync.yaml in the repo root:
 		Args:  cobra.RangeArgs(1, 2),
 		Run: func(cmd *cobra.Command, args []string) {
 			wtPath := args[0]
-			gitArgs := []string{"worktree", "add", wtPath}
+			branchName := strings.TrimSuffix(filepath.Base(wtPath), "/")
+
+			gitArgs := []string{"worktree", "add", "-b", branchName, wtPath}
 			if len(args) == 2 {
 				gitArgs = append(gitArgs, args[1])
 			}

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeGitRunnerWithWorktree struct {
+	fakeGitRunner
+	worktreeAddCalls [][]string
+}
+
+func (f *fakeGitRunnerWithWorktree) Run(dir string, args ...string) error {
+	if len(args) >= 2 && args[0] == "worktree" && args[1] == "add" {
+		f.worktreeAddCalls = append(f.worktreeAddCalls, args)
+		return nil
+	}
+	return f.fakeGitRunner.Run(dir, args...)
+}
+
+func TestWorktreeAdd_CreatesBranchFromPath(t *testing.T) {
+	git := &fakeGitRunnerWithWorktree{
+		fakeGitRunner: fakeGitRunner{
+			values: map[string]string{
+				"__repo_root__": "/tmp/repo",
+			},
+		},
+	}
+
+	appCfg := AppConfig{Worktree: AppWorktreeConfig{DefaultMode: "symlink"}}
+	cmd := buildWorktreeCmd(appCfg, git)
+	cmd.SetArgs([]string{"add", "/tmp/my-feature"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.Len(t, git.worktreeAddCalls, 1)
+
+	call := git.worktreeAddCalls[0]
+	assert.Equal(t, []string{"worktree", "add", "-b", "my-feature", "/tmp/my-feature"}, call)
+}
+
+func TestWorktreeAdd_WithCommitIsh(t *testing.T) {
+	git := &fakeGitRunnerWithWorktree{
+		fakeGitRunner: fakeGitRunner{
+			values: map[string]string{
+				"__repo_root__": "/tmp/repo",
+			},
+		},
+	}
+
+	appCfg := AppConfig{Worktree: AppWorktreeConfig{DefaultMode: "symlink"}}
+	cmd := buildWorktreeCmd(appCfg, git)
+	cmd.SetArgs([]string{"add", "/tmp/my-feature", "main"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.Len(t, git.worktreeAddCalls, 1)
+
+	call := git.worktreeAddCalls[0]
+	assert.Equal(t, []string{"worktree", "add", "-b", "my-feature", "/tmp/my-feature", "main"}, call)
+}
+
+func TestWorktreeAdd_StripsTrailingSlash(t *testing.T) {
+	git := &fakeGitRunnerWithWorktree{
+		fakeGitRunner: fakeGitRunner{
+			values: map[string]string{
+				"__repo_root__": "/tmp/repo",
+			},
+		},
+	}
+
+	appCfg := AppConfig{Worktree: AppWorktreeConfig{DefaultMode: "symlink"}}
+	cmd := buildWorktreeCmd(appCfg, git)
+	cmd.SetArgs([]string{"add", "/tmp/my-feature/"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.Len(t, git.worktreeAddCalls, 1)
+
+	assert.Equal(t, "my-feature", git.worktreeAddCalls[0][3])
+}
+
+func TestWorktreeAdd_WithRelativePath(t *testing.T) {
+	git := &fakeGitRunnerWithWorktree{
+		fakeGitRunner: fakeGitRunner{
+			values: map[string]string{
+				"__repo_root__": "/tmp/repo",
+			},
+		},
+	}
+
+	appCfg := AppConfig{Worktree: AppWorktreeConfig{DefaultMode: "symlink"}}
+	cmd := buildWorktreeCmd(appCfg, git)
+	cmd.SetArgs([]string{"add", "../my-worktree"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.Len(t, git.worktreeAddCalls, 1)
+
+	call := git.worktreeAddCalls[0]
+	assert.Equal(t, "my-worktree", call[3])
+	assert.Equal(t, "../my-worktree", call[4])
+}
+
+func TestWorktreeAdd_WithNestedPath(t *testing.T) {
+	git := &fakeGitRunnerWithWorktree{
+		fakeGitRunner: fakeGitRunner{
+			values: map[string]string{
+				"__repo_root__": "/tmp/repo",
+			},
+		},
+	}
+
+	appCfg := AppConfig{Worktree: AppWorktreeConfig{DefaultMode: "symlink"}}
+	cmd := buildWorktreeCmd(appCfg, git)
+	cmd.SetArgs([]string{"add", "/home/user/projects/feature-x"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.Len(t, git.worktreeAddCalls, 1)
+
+	assert.Equal(t, "feature-x", git.worktreeAddCalls[0][3])
+}
+
+func TestWorktreeAdd_WithCommitHash(t *testing.T) {
+	git := &fakeGitRunnerWithWorktree{
+		fakeGitRunner: fakeGitRunner{
+			values: map[string]string{
+				"__repo_root__": "/tmp/repo",
+			},
+		},
+	}
+
+	appCfg := AppConfig{Worktree: AppWorktreeConfig{DefaultMode: "symlink"}}
+	cmd := buildWorktreeCmd(appCfg, git)
+	cmd.SetArgs([]string{"add", "/tmp/fix-bug", "abc123def456"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.Len(t, git.worktreeAddCalls, 1)
+
+	call := git.worktreeAddCalls[0]
+	assert.Equal(t, "-b", call[2])
+	assert.Equal(t, "fix-bug", call[3])
+	assert.Equal(t, "/tmp/fix-bug", call[4])
+	assert.Equal(t, "abc123def456", call[5])
+}
+
+func initGitRepo(dir string) error {
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	cmd = exec.Command("git", "config", "user.name", "Test")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	cmd = exec.Command("git", "config", "user.email", "test@test.com")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("hello"), 0644); err != nil {
+		return err
+	}
+	cmd = exec.Command("git", "add", ".")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	cmd = exec.Command("git", "commit", "-m", "initial")
+	cmd.Dir = dir
+	return cmd.Run()
+}


### PR DESCRIPTION
## Summary

This PR fixes the worktree add command to always create a new branch instead of creating worktrees in a detached HEAD state.

### Changes
- Use `-b` flag to create new branch from path basename
- Strip trailing slashes to avoid invalid branch names  
- Support commit-ish as base for new branch
- Add comprehensive unit tests

### Before
- `git ctx worktree add /tmp/wt main` → tried to checkout 'main' branch (failed if already checked out)
- `git ctx worktree add /tmp/wt abc123` → created detached HEAD at commit abc123

### After
- `git ctx worktree add /tmp/wt main` → creates new branch 'wt' based on main
- `git ctx worktree add /tmp/wt abc123` → creates new branch 'wt' based on commit abc123

### Test Plan
- [x] All Go tests pass
- [x] Unit tests added for worktree add functionality
- [x] Integration tested with real git repos

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The `worktree add` command now automatically derives and creates a branch from the worktree filesystem path.
  * Optional commit-ish references continue to be supported when creating worktrees.

* **Tests**
  * Introduced comprehensive tests validating worktree add behavior with various path formats and commit reference configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->