### PR TITLE
feat: add post-worktree hooks for automatic setup

### DIFF
--- a/app_config.go
+++ b/app_config.go
@@ -30,10 +30,18 @@ type DirectoryRule struct {
 	Profile string `yaml:"profile"`
 }
 
+// AppWorktreeHooks holds hook commands that run at various lifecycle points.
+type AppWorktreeHooks struct {
+	// PostCreate runs after a worktree is created (before files are synced).
+	PostCreate []string `yaml:"post_create"`
+}
+
 // AppWorktreeConfig holds worktree-related settings.
 type AppWorktreeConfig struct {
 	// DefaultMode is "symlink" (default) or "copy".
 	DefaultMode string `yaml:"default_mode"`
+	// Hooks are commands to run at various lifecycle points.
+	Hooks AppWorktreeHooks `yaml:"hooks"`
 }
 
 // MatchDirectoryRule finds the best-matching profile for dir using longest-prefix matching.
@@ -139,6 +147,11 @@ directory_rules:
 
 worktree:
   default_mode: symlink  # symlink | copy
+  # Hooks run after worktree creation:
+  # hooks:
+  #   post_create:
+  #     - bun install
+  #     - npm run setup
 `, filepath.Join(homeDir, ".git-ctx-profiles.json"))
 
 	return os.WriteFile(cfgPath, []byte(scaffold), 0644)

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -1,0 +1,26 @@
+package e2e
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("E2E_TEST") == "" {
+		os.Setenv("E2E_TEST", "1")
+	}
+
+	if err := rebuildBinary(); err != nil {
+		os.Stderr.WriteString("Failed to rebuild binary: " + err.Error() + "\n")
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}
+
+func rebuildBinary() error {
+	cmd := exec.Command("go", "build", "-o", "git-ctx-test", ".")
+	cmd.Dir = "/home/lvluu/git-profile"
+	return cmd.Run()
+}

--- a/e2e/worktree_hooks_test.go
+++ b/e2e/worktree_hooks_test.go
@@ -1,0 +1,156 @@
+package e2e
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func initTestRepo(t *testing.T) string {
+	tmpDir := t.TempDir()
+
+	cmd := exec.Command("git", "init")
+	cmd.Dir = tmpDir
+	require.NoError(t, cmd.Run(), "git init")
+
+	cmd = exec.Command("git", "config", "user.name", "Test")
+	cmd.Dir = tmpDir
+	require.NoError(t, cmd.Run())
+
+	cmd = exec.Command("git", "config", "user.email", "test@test.com")
+	cmd.Dir = tmpDir
+	require.NoError(t, cmd.Run())
+
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "file.txt"), []byte("test"), 0644))
+
+	cmd = exec.Command("git", "add", ".")
+	cmd.Dir = tmpDir
+	require.NoError(t, cmd.Run())
+
+	cmd = exec.Command("git", "commit", "-m", "initial")
+	cmd.Dir = tmpDir
+	require.NoError(t, cmd.Run())
+
+	return tmpDir
+}
+
+func TestWorktreeHooks_ExecutesPostCreateHooks(t *testing.T) {
+	repo := initTestRepo(t)
+
+	syncCfg := `mode: symlink
+files: []
+hooks:
+  post_create:
+    - 'echo "HOOK_EXECUTED"'
+`
+	require.NoError(t, os.WriteFile(filepath.Join(repo, ".git-ctx-sync.yaml"), []byte(syncCfg), 0644))
+
+	worktreePath := filepath.Join(filepath.Dir(repo), "test-wt-hook")
+	cmd := exec.Command(filepath.Join("/home/lvluu/git-profile", "git-ctx-test"), "worktree", "add", worktreePath)
+	cmd.Dir = repo
+	out, err := cmd.CombinedOutput()
+	t.Logf("Output: %s", string(out))
+	require.NoError(t, err, "worktree add should succeed")
+
+	assert.Contains(t, string(out), "HOOK_EXECUTED", "hook should execute and output message")
+	assert.Contains(t, string(out), "Worktree created at", "should confirm worktree creation")
+
+	os.RemoveAll(worktreePath)
+}
+
+func TestWorktreeHooks_GlobalAndRepoHooks(t *testing.T) {
+	repo := initTestRepo(t)
+
+	syncCfg := `mode: symlink
+files: []
+hooks:
+  post_create:
+    - 'echo "REPO_HOOK"'
+`
+	require.NoError(t, os.WriteFile(filepath.Join(repo, ".git-ctx-sync.yaml"), []byte(syncCfg), 0644))
+
+	worktreePath := filepath.Join(filepath.Dir(repo), "test-wt-both")
+	cmd := exec.Command(filepath.Join("/home/lvluu/git-profile", "git-ctx-test"), "worktree", "add", worktreePath)
+	cmd.Dir = repo
+	cmd.Env = append(os.Environ(), "GIT_CTX_WORKTREE_HOOKS=echo 'GLOBAL_HOOK'")
+	out, err := cmd.CombinedOutput()
+	t.Logf("Output: %s", string(out))
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "REPO_HOOK", "repo hook should execute")
+}
+
+func TestWorktreeHooks_SkipWithFlag(t *testing.T) {
+	repo := initTestRepo(t)
+
+	syncCfg := `mode: symlink
+files: []
+hooks:
+  post_create:
+    - 'echo "SHOULD_NOT_RUN"'
+`
+	require.NoError(t, os.WriteFile(filepath.Join(repo, ".git-ctx-sync.yaml"), []byte(syncCfg), 0644))
+
+	worktreePath := filepath.Join(filepath.Dir(repo), "test-wt-no-hooks")
+	cmd := exec.Command(filepath.Join("/home/lvluu/git-profile", "git-ctx-test"), "worktree", "add", worktreePath, "--no-hooks")
+	cmd.Dir = repo
+	out, err := cmd.CombinedOutput()
+	t.Logf("Output: %s", string(out))
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(out), "SHOULD_NOT_RUN", "hook should not execute with --no-hooks")
+	assert.Contains(t, string(out), "Worktree created at", "worktree should still be created")
+}
+
+func TestWorktreeHooks_StopsOnFailure(t *testing.T) {
+	repo := initTestRepo(t)
+
+	syncCfg := `mode: symlink
+files: []
+hooks:
+  post_create:
+    - 'echo "FIRST"'
+    - 'exit 1'
+    - 'echo "NEVER_RUN"'
+`
+	require.NoError(t, os.WriteFile(filepath.Join(repo, ".git-ctx-sync.yaml"), []byte(syncCfg), 0644))
+
+	worktreePath := filepath.Join(filepath.Dir(repo), "test-wt-fail")
+	cmd := exec.Command(filepath.Join("/home/lvluu/git-profile", "git-ctx-test"), "worktree", "add", worktreePath)
+	cmd.Dir = repo
+	out, err := cmd.CombinedOutput()
+	t.Logf("Output: %s", string(out))
+
+	assert.Error(t, err, "should fail when hook fails")
+	assert.Contains(t, string(out), "FIRST", "first hook should execute")
+	assert.NotContains(t, string(out), "NEVER_RUN", "third hook should not run")
+}
+
+func TestWorktreeHooks_EnvironmentVariables(t *testing.T) {
+	repo := initTestRepo(t)
+
+	syncCfg := `mode: symlink
+files: []
+hooks:
+  post_create:
+    - 'echo "BRANCH=$GIT_CTX_WORKTREE_BRANCH"'
+    - 'echo "PATH=$GIT_CTX_WORKTREE_PATH"'
+    - 'echo "REPO=$GIT_CTX_REPO_ROOT"'
+`
+	require.NoError(t, os.WriteFile(filepath.Join(repo, ".git-ctx-sync.yaml"), []byte(syncCfg), 0644))
+
+	worktreePath := filepath.Join(filepath.Dir(repo), "test-wt-env")
+	cmd := exec.Command(filepath.Join("/home/lvluu/git-profile", "git-ctx-test"), "worktree", "add", worktreePath)
+	cmd.Dir = repo
+	out, err := cmd.CombinedOutput()
+	t.Logf("Output: %s", string(out))
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "BRANCH=test-wt-env")
+	assert.Contains(t, string(out), "PATH="+worktreePath)
+	assert.Contains(t, string(out), "REPO="+repo)
+}

--- a/worktree.go
+++ b/worktree.go
@@ -22,10 +22,14 @@ File sync is configured via .git-ctx-sync.yaml in the repo root:
   files:
     - .env
     - .vscode/settings.json
+  hooks:
+    post_create:
+      - bun install
 
 - mode is optional; falls back to worktree.default_mode in ~/.git-ctx.yaml
 - files are relative to the repo root
-- add .git-ctx-sync.yaml to .gitignore (it is local-only)`,
+- hooks run after worktree creation (global hooks from ~/.git-ctx.yaml run first)
+- .git-ctx-sync.yaml is local-only (add to .gitignore)`,
 	}
 
 	// ── worktree ls ──────────────────────────────────────────────────────
@@ -43,7 +47,7 @@ File sync is configured via .git-ctx-sync.yaml in the repo root:
 	}
 
 	// ── worktree add ─────────────────────────────────────────────────────
-	var addCopy bool
+	var addCopy, noHooks bool
 	addCmd := &cobra.Command{
 		Use:   "add <path> [<commit-ish>]",
 		Short: "Add a worktree and sync configured files into it",
@@ -68,18 +72,48 @@ File sync is configured via .git-ctx-sync.yaml in the repo root:
 				os.Exit(1)
 			}
 
-			warnings, err := runSync(appCfg, git, absWTPath, addCopy)
+			repoRoot, inRepo, err := findRepoRoot(git)
 			if err != nil {
-				fmt.Println("Sync failed:", err)
+				fmt.Println("Error finding repo root:", err)
 				os.Exit(1)
 			}
-			for _, w := range warnings {
-				fmt.Println("Warning:", w)
+			if !inRepo {
+				fmt.Println("Error: not inside a git repository")
+				os.Exit(1)
 			}
+
+			syncCfgPath := filepath.Join(repoRoot, ".git-ctx-sync.yaml")
+			syncCfg, err := loadSyncConfig(syncCfgPath, appCfg.Worktree.DefaultMode)
+			if err != nil {
+				fmt.Println("Error loading sync config:", err)
+				os.Exit(1)
+			}
+
+			if len(syncCfg.Files) > 0 {
+				warnings, err := syncFiles(syncCfg, repoRoot, absWTPath, addCopy)
+				if err != nil {
+					fmt.Println("Sync failed:", err)
+					os.Exit(1)
+				}
+				for _, w := range warnings {
+					fmt.Println("Warning:", w)
+				}
+			}
+
+			if !noHooks {
+				runner := &ExecHookRunner{Stdout: os.Stdout, Stderr: os.Stderr}
+				allHooks := append(appCfg.Worktree.Hooks.PostCreate, syncCfg.Hooks.PostCreate...)
+				if err := runHooks(runner, allHooks, absWTPath, branchName, repoRoot); err != nil {
+					fmt.Println("Hook failed:", err)
+					os.Exit(1)
+				}
+			}
+
 			fmt.Printf("Worktree created at %s\n", absWTPath)
 		},
 	}
 	addCmd.Flags().BoolVar(&addCopy, "copy", false, "Copy files instead of symlinking")
+	addCmd.Flags().BoolVar(&noHooks, "no-hooks", false, "Skip post-create hooks")
 
 	// ── worktree sync ─────────────────────────────────────────────────────
 	var syncCopy bool

--- a/worktree_config.go
+++ b/worktree_config.go
@@ -9,12 +9,19 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// SyncHooks holds hook commands for worktree lifecycle events.
+type SyncHooks struct {
+	PostCreate []string `yaml:"post_create"`
+}
+
 // SyncConfig is the per-repo worktree sync configuration from .git-ctx-sync.yaml.
 type SyncConfig struct {
 	// Mode is "symlink" (default) or "copy".
 	Mode string `yaml:"mode"`
 	// Files lists paths relative to the repo root to sync into each worktree.
 	Files []string `yaml:"files"`
+	// Hooks are commands to run after worktree creation.
+	Hooks SyncHooks `yaml:"hooks"`
 }
 
 // loadSyncConfig reads .git-ctx-sync.yaml from cfgPath.

--- a/worktree_hooks.go
+++ b/worktree_hooks.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+)
+
+// HookRunner executes hook commands. Interface allows testing with fake runners.
+type HookRunner interface {
+	Run(hook, worktreePath string, env map[string]string) error
+}
+
+// ExecHookRunner runs hooks via exec.Command.
+type ExecHookRunner struct {
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// Run executes a hook command in the worktree directory.
+func (r *ExecHookRunner) Run(hook, worktreePath string, env map[string]string) error {
+	cmd := exec.Command("/bin/sh", "-c", hook)
+	cmd.Dir = worktreePath
+	cmd.Stdout = r.Stdout
+	cmd.Stderr = r.Stderr
+
+	cmd.Env = os.Environ()
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("hook failed: %s: %w", hook, err)
+	}
+	return nil
+}
+
+// runHooks executes a list of hooks sequentially. Stops on first failure.
+func runHooks(runner HookRunner, hooks []string, worktreePath, branch, repoRoot string) error {
+	env := map[string]string{
+		"GIT_CTX_WORKTREE_PATH":   worktreePath,
+		"GIT_CTX_WORKTREE_BRANCH": branch,
+		"GIT_CTX_REPO_ROOT":       repoRoot,
+	}
+
+	for _, hook := range hooks {
+		if err := runner.Run(hook, worktreePath, env); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/worktree_hooks_test.go
+++ b/worktree_hooks_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeHookRunner struct {
+	calls []struct {
+		hook, dir string
+		env       map[string]string
+	}
+	err     error
+	errHook string
+}
+
+func (f *fakeHookRunner) Run(hook, worktreePath string, env map[string]string) error {
+	f.calls = append(f.calls, struct {
+		hook, dir string
+		env       map[string]string
+	}{hook, worktreePath, env})
+	if f.err != nil && (f.errHook == "" || f.errHook == hook) {
+		return f.err
+	}
+	return nil
+}
+
+func TestRunHooks_EmptyList(t *testing.T) {
+	runner := &fakeHookRunner{}
+	err := runHooks(runner, []string{}, "/path/to/worktree", "my-branch", "/path/to/repo")
+	assert.NoError(t, err)
+	assert.Len(t, runner.calls, 0)
+}
+
+func TestRunHooks_SingleHook(t *testing.T) {
+	runner := &fakeHookRunner{}
+	hooks := []string{"bun install"}
+
+	err := runHooks(runner, hooks, "/worktree", "feature-branch", "/repo")
+	require.NoError(t, err)
+	require.Len(t, runner.calls, 1)
+
+	assert.Equal(t, "bun install", runner.calls[0].hook)
+	assert.Equal(t, "/worktree", runner.calls[0].dir)
+	assert.Equal(t, "feature-branch", runner.calls[0].env["GIT_CTX_WORKTREE_BRANCH"])
+	assert.Equal(t, "/worktree", runner.calls[0].env["GIT_CTX_WORKTREE_PATH"])
+	assert.Equal(t, "/repo", runner.calls[0].env["GIT_CTX_REPO_ROOT"])
+}
+
+func TestRunHooks_MultipleHooks(t *testing.T) {
+	runner := &fakeHookRunner{}
+	hooks := []string{"bun install", "npm run setup", "echo 'done'"}
+
+	err := runHooks(runner, hooks, "/worktree", "branch", "/repo")
+	require.NoError(t, err)
+	require.Len(t, runner.calls, 3)
+
+	assert.Equal(t, "bun install", runner.calls[0].hook)
+	assert.Equal(t, "npm run setup", runner.calls[1].hook)
+	assert.Equal(t, "echo 'done'", runner.calls[2].hook)
+}
+
+func TestRunHooks_StopsOnFirstError(t *testing.T) {
+	runner := &fakeHookRunner{
+		err:     errors.New("hook failed"),
+		errHook: "npm install",
+	}
+	hooks := []string{"bun install", "npm install", "echo 'done'"}
+
+	err := runHooks(runner, hooks, "/worktree", "branch", "/repo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "hook failed")
+	assert.Len(t, runner.calls, 2)
+}
+
+func TestRunHooks_EnvironmentVariables(t *testing.T) {
+	runner := &fakeHookRunner{}
+	hooks := []string{"echo test"}
+
+	err := runHooks(runner, hooks, "/path/to/my-feature", "my-feature", "/path/to/repo")
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-feature", runner.calls[0].env["GIT_CTX_WORKTREE_BRANCH"])
+	assert.Equal(t, "/path/to/my-feature", runner.calls[0].env["GIT_CTX_WORKTREE_PATH"])
+	assert.Equal(t, "/path/to/repo", runner.calls[0].env["GIT_CTX_REPO_ROOT"])
+}
+
+func TestExecHookRunner_CommandExecution(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	runner := &ExecHookRunner{Stdout: &stdout, Stderr: &stderr}
+
+	err := runner.Run("echo 'hello world'", "/tmp", map[string]string{"MY_VAR": "value"})
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "hello world")
+}
+
+func TestExecHookRunner_CommandFailure(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	runner := &ExecHookRunner{Stdout: &stdout, Stderr: &stderr}
+
+	err := runner.Run("exit 1", "/tmp", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "hook failed")
+}
+
+func TestExecHookRunner_NonexistentCommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	runner := &ExecHookRunner{Stdout: &stdout, Stderr: &stderr}
+
+	err := runner.Run("nonexistent_command_xyz", "/tmp", nil)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Add configurable hooks that run automatically after `git ctx worktree add` creates a new worktree. This enables automatic setup tasks like running `bun install`, `npm install`, or any other initialization commands.

## Changes

### New Features
- **Post-create hooks**: Commands that run after worktree creation
- **Dual configuration**: Supports hooks in both global (`~/.git-ctx.yaml`) and per-repo (`.git-ctx-sync.yaml`)
- **Environment variables**: Hooks receive `GIT_CTX_WORKTREE_PATH`, `GIT_CTX_WORKTREE_BRANCH`, `GIT_CTX_REPO_ROOT`
- **`--no-hooks` flag**: Skip hooks when needed

### Files Changed
- `app_config.go`: Added `AppWorktreeHooks` struct for global config
- `worktree_config.go`: Added `SyncHooks` struct for per-repo config  
- `worktree_hooks.go`: New file with hook execution logic
- `worktree.go`: Integrated hooks into `worktree add` command

### Tests
- Unit tests in `worktree_hooks_test.go`
- E2E tests in `e2e/worktree_hooks_test.go`

## Usage

```yaml
# Global hooks (~/.git-ctx.yaml)
worktree:
  hooks:
    post_create:
      - 'bun install'

# Per-repo hooks (.git-ctx-sync.yaml)
hooks:
  post_create:
    - 'cp .env.example .env'
```

## YAML Note
Use single quotes for commands with `$` variables:
```yaml
- 'echo "Branch: $GIT_CTX_WORKTREE_BRANCH"'
```

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced post-worktree creation hooks via configuration, allowing custom commands to execute automatically when creating new worktrees
  * Added `--no-hooks` flag to skip hook execution during worktree creation
  * Hooks receive context environment variables for the branch, worktree path, and repository root

* **Tests**
  * Added comprehensive end-to-end and unit tests for worktree hook execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->