### PR TITLE
feat(worktree): add bidirectional sync and watch mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/lvluu/git-ctx
 go 1.23.3
 
 require (
+	github.com/fsnotify/fsnotify v1.8.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.10.0
@@ -15,5 +16,5 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/sys v0.1.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
+github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
@@ -21,8 +23,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
-golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -3,10 +3,12 @@ package app
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/lvluu/git-ctx/internal/config"
 	"github.com/lvluu/git-ctx/internal/git"
@@ -367,6 +369,9 @@ File sync is configured via .git-ctx-sync.yaml in the repo root:
 	worktreeCmd.AddCommand(buildWorktreeLsCmd(g))
 	worktreeCmd.AddCommand(buildWorktreeAddCmd(appCfg, g))
 	worktreeCmd.AddCommand(buildWorktreeSyncCmd(appCfg, g))
+	worktreeCmd.AddCommand(buildWorktreePushCmd(appCfg, g))
+	worktreeCmd.AddCommand(buildWorktreePullCmd(appCfg, g))
+	worktreeCmd.AddCommand(buildWorktreeWatchCmd(appCfg, g))
 
 	return worktreeCmd
 }
@@ -514,6 +519,124 @@ func buildWorktreeSyncCmd(appCfg config.AppConfig, g git.Runner) *cobra.Command 
 	cmd.Flags().BoolVar(&syncCopy, "copy", false, "Copy files instead of symlinking")
 	return cmd
 }
+
+// buildWorktreePushCmd pushes configured files from the repo root into a worktree.
+func buildWorktreePushCmd(appCfg config.AppConfig, g git.Runner) *cobra.Command {
+	var pushCopy bool
+
+	cmd := &cobra.Command{
+		Use:   "push <worktree-path>",
+		Short: "Push files from the primary worktree into a worktree",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			absPath, err := filepath.Abs(args[0])
+			if err != nil {
+				fmt.Println("Error resolving path:", err)
+				os.Exit(1)
+			}
+			warnings, err := worktree.RunSyncPush(appCfg, g, absPath, pushCopy)
+			if err != nil {
+				fmt.Println("Push failed:", err)
+				os.Exit(1)
+			}
+			for _, w := range warnings {
+				fmt.Println("Warning:", w)
+			}
+			fmt.Printf("Pushed files to %s\n", absPath)
+		},
+	}
+	cmd.Flags().BoolVar(&pushCopy, "copy", false, "Copy files instead of symlinking")
+	return cmd
+}
+
+// buildWorktreePullCmd pulls configured files from a worktree back to the primary.
+func buildWorktreePullCmd(appCfg config.AppConfig, g git.Runner) *cobra.Command {
+	var pullCopy bool
+
+	cmd := &cobra.Command{
+		Use:   "pull <worktree-path>",
+		Short: "Pull files from a worktree into the primary worktree",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			absPath, err := filepath.Abs(args[0])
+			if err != nil {
+				fmt.Println("Error resolving path:", err)
+				os.Exit(1)
+			}
+			warnings, err := worktree.RunSyncPull(appCfg, g, absPath, pullCopy)
+			if err != nil {
+				var conflictErr *worktree.ConflictError
+				if errors.As(err, &conflictErr) {
+					fmt.Println("Pull aborted due to conflict:", conflictErr.Error())
+				} else {
+					fmt.Println("Pull failed:", err)
+				}
+				os.Exit(1)
+			}
+			for _, w := range warnings {
+				fmt.Println("Warning:", w)
+			}
+			fmt.Printf("Pulled files from %s\n", absPath)
+		},
+	}
+	cmd.Flags().BoolVar(&pullCopy, "copy", false, "Copy files instead of symlinking")
+	return cmd
+}
+
+// buildWorktreeWatchCmd starts a watch loop that continuously syncs files.
+func buildWorktreeWatchCmd(appCfg config.AppConfig, g git.Runner) *cobra.Command {
+	var watchCopy bool
+
+	cmd := &cobra.Command{
+		Use:   "watch [worktree-path]",
+		Short: "Watch and continuously sync files between worktrees",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			repoRoot, inRepo, err := git.FindRepoRoot(g)
+			if err != nil || !inRepo {
+				fmt.Println("Error: not inside a git repository")
+				os.Exit(1)
+			}
+
+			var dstRoot string
+			if len(args) == 1 {
+				dstRoot, _ = filepath.Abs(args[0])
+			} else {
+				paths, err := worktree.ListWorktreePaths(g)
+				if err != nil || len(paths) <= 1 {
+					fmt.Println("No additional worktrees found.")
+					os.Exit(0)
+				}
+				dstRoot = paths[1] // sync to the first non-primary worktree
+			}
+
+			syncCfg, err := worktree.LoadSyncConfig(filepath.Join(repoRoot, ".git-ctx-sync.yaml"), appCfg.Worktree.DefaultMode)
+			if err != nil || len(syncCfg.Files) == 0 {
+				fmt.Println("No sync files configured in .git-ctx-sync.yaml")
+				os.Exit(0)
+			}
+
+			fmt.Printf("Watching %s for changes (debounce: %v)\n",
+				strings.Join(syncCfg.Files, ", "), worktree.DefaultWatchConfig.Debounce)
+			fmt.Printf("Syncing to: %s\n", dstRoot)
+
+			worktree.WatchLoop(syncCfg, repoRoot, dstRoot, watchCopy, worktree.DefaultWatchConfig,
+				func(warnings []string) {
+					for _, w := range warnings {
+						fmt.Println("Warning:", w)
+					}
+					fmt.Println("Synced")
+				},
+				func(err error) {
+					fmt.Println("Watch error:", err)
+				},
+			)
+		},
+	}
+	cmd.Flags().BoolVar(&watchCopy, "copy", false, "Copy files instead of symlinking")
+	return cmd
+}
+
 
 // BuildWorktreeCmd builds the worktree command group.
 func BuildWorktreeCmd(appCfg config.AppConfig, g git.Runner) *cobra.Command {

--- a/internal/worktree/sync.go
+++ b/internal/worktree/sync.go
@@ -2,11 +2,17 @@
 package worktree
 
 import (
+	"crypto/sha256"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/lvluu/git-ctx/internal/config"
 	"github.com/lvluu/git-ctx/internal/git"
 	"gopkg.in/yaml.v3"
@@ -147,3 +153,309 @@ func copyFile(src, dst string) error {
 	_, err = out.ReadFrom(in)
 	return err
 }
+
+// SyncDirection specifies the direction of a sync operation.
+type SyncDirection string
+
+const (
+	// Push syncs files from the primary worktree to other worktrees.
+	Push SyncDirection = "push"
+	// Pull syncs files from a non-primary worktree back to the primary.
+	Pull SyncDirection = "pull"
+)
+
+// ErrConflict is returned when a file has been modified in both source and
+// destination worktrees since the last sync.
+var ErrConflict = errors.New("sync conflict detected")
+
+// ConflictError reports which files conflicted.
+type ConflictError struct {
+	Files []string
+}
+
+func (e *ConflictError) Error() string {
+	return fmt.Sprintf("sync conflict: %d file(s) modified in both worktrees: %s",
+		len(e.Files), strings.Join(e.Files, ", "))
+}
+
+// fileHash returns a SHA-256 hash of the file contents at path.
+func fileHash(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return nil, err
+	}
+	return h.Sum(nil), nil
+}
+
+// hasConflict checks whether a file has been modified in both src and dst since
+// the last sync by comparing content hashes. A conflict exists when both files
+// differ and the destination was modified at or after the source (within a 1-second
+// window to account for clock imprecision). Returns the conflicting files.
+func hasConflict(src, dst string) ([]string, error) {
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return nil, err
+	}
+
+	dstInfo, err := os.Stat(dst)
+	if err != nil {
+		// Destination missing — no conflict.
+		return nil, nil
+	}
+
+	diff := dstInfo.ModTime().Sub(srcInfo.ModTime())
+
+	// If dst was modified strictly before src (by more than 1 second), no conflict.
+	if diff < -time.Second {
+		return nil, nil
+	}
+
+	// dst was modified at or after src — content may have diverged.
+	srcHash, err := fileHash(src)
+	if err != nil {
+		return nil, err
+	}
+	dstHash, err := fileHash(dst)
+	if err != nil {
+		return nil, err
+	}
+
+	if !bytesEqual(srcHash, dstHash) {
+		return []string{filepath.Base(src)}, nil
+	}
+	return nil, nil
+}
+
+func abs(d time.Duration) time.Duration {
+	if d < 0 {
+		return -d
+	}
+	return d
+}
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// SyncDirectionFiles syncs files in the given direction. Pull checks for
+// conflicts before overwriting; Push overwrites without conflict checks.
+func SyncDirectionFiles(cfg SyncConfig, srcRoot, dstRoot string, direction SyncDirection, copyOverride bool) (warnings []string, err error) {
+	useCopy := copyOverride || cfg.Mode == "copy"
+
+	for _, rel := range cfg.Files {
+		src := filepath.Join(srcRoot, rel)
+		dst := filepath.Join(dstRoot, rel)
+
+		if _, err := os.Stat(src); os.IsNotExist(err) {
+			warnings = append(warnings, fmt.Sprintf("skipping %s: not found in source worktree", rel))
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+			return warnings, fmt.Errorf("creating parent dir for %s: %w", rel, err)
+		}
+
+		// For pull operations, detect conflicts (file changed in both worktrees).
+		if direction == Pull {
+			conflicts, err := hasConflict(src, dst)
+			if err != nil && !os.IsNotExist(err) {
+				return warnings, fmt.Errorf("checking conflict for %s: %w", rel, err)
+			}
+			if len(conflicts) > 0 {
+				return warnings, &ConflictError{Files: conflicts}
+			}
+		}
+
+		if useCopy {
+			if err := copyFile(src, dst); err != nil {
+				return warnings, fmt.Errorf("copying %s: %w", rel, err)
+			}
+		} else {
+			absTarget, err := filepath.Abs(src)
+			if err != nil {
+				return warnings, fmt.Errorf("resolving absolute path for %s: %w", rel, err)
+			}
+			_ = os.Remove(dst)
+			if err := os.Symlink(absTarget, dst); err != nil {
+				return warnings, fmt.Errorf("symlinking %s: %w", rel, err)
+			}
+		}
+	}
+
+	return warnings, nil
+}
+
+// RunSyncPush pushes files from the repo root to a specific worktree.
+func RunSyncPush(appCfg config.AppConfig, g git.Runner, dstWorktree string, copyOverride bool) ([]string, error) {
+	repoRoot, inRepo, err := git.FindRepoRoot(g)
+	if err != nil {
+		return nil, err
+	}
+	if !inRepo {
+		return nil, fmt.Errorf("not inside a git repository")
+	}
+
+	cfg, err := loadSyncConfigForPath(filepath.Join(repoRoot, ".git-ctx-sync.yaml"), appCfg.Worktree.DefaultMode)
+	if err != nil {
+		return nil, err
+	}
+	if len(cfg.Files) == 0 {
+		return nil, nil
+	}
+	return SyncDirectionFiles(cfg, repoRoot, dstWorktree, Push, copyOverride)
+}
+
+// RunSyncPull pulls files from a non-primary worktree back to the repo root.
+// It detects conflicts where the same file was modified in both worktrees.
+func RunSyncPull(appCfg config.AppConfig, g git.Runner, srcWorktree string, copyOverride bool) ([]string, error) {
+	repoRoot, inRepo, err := git.FindRepoRoot(g)
+	if err != nil {
+		return nil, err
+	}
+	if !inRepo {
+		return nil, fmt.Errorf("not inside a git repository")
+	}
+
+	cfg, err := loadSyncConfigForPath(filepath.Join(repoRoot, ".git-ctx-sync.yaml"), appCfg.Worktree.DefaultMode)
+	if err != nil {
+		return nil, err
+	}
+	if len(cfg.Files) == 0 {
+		return nil, nil
+	}
+	return SyncDirectionFiles(cfg, srcWorktree, repoRoot, Pull, copyOverride)
+}
+
+// loadSyncConfigForPath is an internal version of LoadSyncConfig that returns an
+// error (rather than defaults) when the config file is missing.
+func loadSyncConfigForPath(cfgPath string, defaultMode string) (SyncConfig, error) {
+	cfg := SyncConfig{Mode: defaultMode}
+
+	data, err := os.ReadFile(cfgPath)
+	if os.IsNotExist(err) {
+		return cfg, fmt.Errorf("no .git-ctx-sync.yaml found in %s", filepath.Dir(cfgPath))
+	}
+	if err != nil {
+		return cfg, err
+	}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return cfg, fmt.Errorf("parsing %s: %w", cfgPath, err)
+	}
+	if cfg.Mode == "" {
+		cfg.Mode = defaultMode
+	}
+	return cfg, nil
+}
+
+// WatchConfig holds configuration for a watch loop.
+type WatchConfig struct {
+	// Debounce is the minimum interval between sync events for the same file.
+	Debounce time.Duration
+}
+
+// DefaultWatchConfig is the default WatchConfig.
+var DefaultWatchConfig = WatchConfig{
+	Debounce: 500 * time.Millisecond,
+}
+
+// WatchLoop watches srcRoot for changes to the files listed in cfg and syncs
+// them to dstRoot. It returns when the watcher is closed or on error.
+func WatchLoop(cfg SyncConfig, srcRoot, dstRoot string, copyOverride bool, wcfg WatchConfig, onSync func([]string), onError func(error)) {
+	debounce := wcfg.Debounce
+	if debounce == 0 {
+		debounce = DefaultWatchConfig.Debounce
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		onError(fmt.Errorf("creating watcher: %w", err))
+		return
+	}
+	defer watcher.Close()
+
+	// Collect watched dirs.
+	watched := make(map[string]bool)
+	for _, rel := range cfg.Files {
+		dir := filepath.Dir(filepath.Join(srcRoot, rel))
+		if !watched[dir] {
+			if err := watcher.Add(dir); err != nil {
+				onError(fmt.Errorf("watching %s: %w", dir, err))
+				return
+			}
+			watched[dir] = true
+		}
+	}
+
+	// Deduplicate file events per debounce window.
+	type pendingSync struct {
+		mu    sync.Mutex
+		timer *time.Timer
+		files []string
+	}
+	ps := &pendingSync{}
+
+	scheduleSync := func() {
+		ps.mu.Lock()
+		if ps.timer != nil {
+			ps.mu.Unlock()
+			return
+		}
+		ps.mu.Unlock()
+		ps.mu.Lock()
+		ps.timer = time.AfterFunc(debounce, func() {
+			ps.mu.Lock()
+			files := ps.files
+			ps.files = nil
+			ps.timer = nil
+			ps.mu.Unlock()
+			warnings, err := SyncDirectionFiles(cfg, srcRoot, dstRoot, Push, copyOverride)
+			if err != nil {
+				onError(err)
+				return
+			}
+			onSync(warnings)
+			_ = files
+		})
+		ps.mu.Unlock()
+	}
+
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+			if event.Op&fsnotify.Write == 0 {
+				continue
+			}
+			for _, rel := range cfg.Files {
+				if filepath.Join(srcRoot, rel) == event.Name {
+					ps.mu.Lock()
+					ps.files = append(ps.files, rel)
+					ps.mu.Unlock()
+					scheduleSync()
+					break
+				}
+			}
+		case err := <-watcher.Errors:
+			if err != nil {
+				onError(fmt.Errorf("watcher error: %w", err))
+				return
+			}
+		}
+	}
+}
+

--- a/internal/worktree/sync_test.go
+++ b/internal/worktree/sync_test.go
@@ -4,43 +4,47 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoadSyncConfig(t *testing.T) {
 	t.Run("non-existent returns defaults", func(t *testing.T) {
 		tmp := t.TempDir()
 		cfg, err := LoadSyncConfig(filepath.Join(tmp, "sync.yaml"), "symlink")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if cfg.Mode != "symlink" {
-			t.Errorf("expected 'symlink', got %s", cfg.Mode)
-		}
-		if len(cfg.Files) != 0 {
-			t.Errorf("expected 0 files, got %d", len(cfg.Files))
-		}
+		require.NoError(t, err)
+		assert.Equal(t, "symlink", cfg.Mode)
+		assertEmpty(t, cfg.Files)
 	})
 
 	t.Run("loads valid config", func(t *testing.T) {
 		tmp := t.TempDir()
 		path := filepath.Join(tmp, "sync.yaml")
-		os.WriteFile(path, []byte(`
+		err := os.WriteFile(path, []byte(`
 mode: copy
 files:
   - .env
   - .vscode/settings.json
 `), 0644)
+		require.NoError(t, err)
 
 		cfg, err := LoadSyncConfig(path, "symlink")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if cfg.Mode != "copy" {
-			t.Errorf("expected 'copy', got %s", cfg.Mode)
-		}
-		if len(cfg.Files) != 2 {
-			t.Errorf("expected 2 files, got %d", len(cfg.Files))
-		}
+		require.NoError(t, err)
+		assert.Equal(t, "copy", cfg.Mode)
+		assert.Len(t, cfg.Files, 2)
+	})
+
+	t.Run("missing mode falls back to default", func(t *testing.T) {
+		tmp := t.TempDir()
+		path := filepath.Join(tmp, "sync.yaml")
+		err := os.WriteFile(path, []byte(`files: [.env]`), 0644)
+		require.NoError(t, err)
+
+		cfg, err := LoadSyncConfig(path, "copy")
+		require.NoError(t, err)
+		assert.Equal(t, "copy", cfg.Mode)
 	})
 }
 
@@ -52,17 +56,286 @@ func TestSyncFiles(t *testing.T) {
 		os.MkdirAll(src, 0755)
 		os.MkdirAll(dst, 0755)
 
-		cfg := SyncConfig{
-			Mode:  "copy",
-			Files: []string{"missing.txt"},
-		}
-
+		cfg := SyncConfig{Mode: "copy", Files: []string{"missing.txt"}}
 		warnings, err := SyncFiles(cfg, src, dst, false)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(warnings) != 1 {
-			t.Errorf("expected 1 warning, got %d", len(warnings))
-		}
+		require.NoError(t, err)
+		assert.Len(t, warnings, 1)
+		assert.Contains(t, warnings[0], "missing.txt")
 	})
+
+	t.Run("copies file when mode is copy", func(t *testing.T) {
+		tmp := t.TempDir()
+		src := filepath.Join(tmp, "src")
+		dst := filepath.Join(tmp, "dst")
+		os.MkdirAll(src, 0755)
+		os.MkdirAll(dst, 0755)
+
+		srcFile := filepath.Join(src, "config.yaml")
+		err := os.WriteFile(srcFile, []byte("hello: world\n"), 0644)
+		require.NoError(t, err)
+
+		cfg := SyncConfig{Mode: "copy", Files: []string{"config.yaml"}}
+		warnings, err := SyncFiles(cfg, src, dst, false)
+		require.NoError(t, err)
+		assert.Empty(t, warnings)
+
+		data, err := os.ReadFile(filepath.Join(dst, "config.yaml"))
+		require.NoError(t, err)
+		assert.Equal(t, "hello: world\n", string(data))
+	})
+
+	t.Run("copyOverride forces copy even in symlink mode", func(t *testing.T) {
+		tmp := t.TempDir()
+		src := filepath.Join(tmp, "src")
+		dst := filepath.Join(tmp, "dst")
+		os.MkdirAll(src, 0755)
+		os.MkdirAll(dst, 0755)
+
+		srcFile := filepath.Join(src, "config.yaml")
+		err := os.WriteFile(srcFile, []byte("hello: world\n"), 0644)
+		require.NoError(t, err)
+
+		cfg := SyncConfig{Mode: "symlink", Files: []string{"config.yaml"}}
+		warnings, err := SyncFiles(cfg, src, dst, true) // copyOverride=true
+		require.NoError(t, err)
+		assert.Empty(t, warnings)
+
+		// Verify it's a regular file, not a symlink.
+		info, err := os.Lstat(filepath.Join(dst, "config.yaml"))
+		require.NoError(t, err)
+		assert.NotEqual(t, os.ModeSymlink, info.Mode()&os.ModeSymlink)
+	})
+}
+
+func TestSyncDirectionFiles_Push(t *testing.T) {
+	t.Run("push syncs files without conflict check", func(t *testing.T) {
+		tmp := t.TempDir()
+		src := filepath.Join(tmp, "src")
+		dst := filepath.Join(tmp, "dst")
+		os.MkdirAll(src, 0755)
+		os.MkdirAll(dst, 0755)
+
+		// Write different content to src and dst.
+		err := os.WriteFile(filepath.Join(src, "shared.txt"), []byte("src version\n"), 0644)
+		require.NoError(t, err)
+		err = os.WriteFile(filepath.Join(dst, "shared.txt"), []byte("dst version\n"), 0644)
+		require.NoError(t, err)
+
+		cfg := SyncConfig{Mode: "copy", Files: []string{"shared.txt"}}
+		warnings, err := SyncDirectionFiles(cfg, src, dst, Push, false)
+		require.NoError(t, err)
+		assert.Empty(t, warnings)
+
+		// Push should have overwritten dst without error.
+		data, err := os.ReadFile(filepath.Join(dst, "shared.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "src version\n", string(data))
+	})
+}
+
+func TestSyncDirectionFiles_Pull_Conflict(t *testing.T) {
+	t.Run("pull detects conflict when both files differ", func(t *testing.T) {
+		tmp := t.TempDir()
+		src := filepath.Join(tmp, "src")
+		dst := filepath.Join(tmp, "dst")
+		os.MkdirAll(src, 0755)
+		os.MkdirAll(dst, 0755)
+
+		// Write different content with different mtimes (1 second apart).
+		err := os.WriteFile(filepath.Join(src, "conflicted.txt"), []byte("src content\n"), 0644)
+		require.NoError(t, err)
+		time.Sleep(1100 * time.Millisecond)
+		err = os.WriteFile(filepath.Join(dst, "conflicted.txt"), []byte("dst content\n"), 0644)
+		require.NoError(t, err)
+
+		cfg := SyncConfig{Mode: "copy", Files: []string{"conflicted.txt"}}
+		_, err = SyncDirectionFiles(cfg, src, dst, Pull, false)
+		require.Error(t, err)
+
+		var conflictErr *ConflictError
+		assert.ErrorAs(t, err, &conflictErr)
+		assert.Contains(t, conflictErr.Files, "conflicted.txt")
+	})
+
+	t.Run("pull succeeds when only destination changed", func(t *testing.T) {
+		tmp := t.TempDir()
+		src := filepath.Join(tmp, "src")
+		dst := filepath.Join(tmp, "dst")
+		os.MkdirAll(src, 0755)
+		os.MkdirAll(dst, 0755)
+
+		// Write same content to both.
+		err := os.WriteFile(filepath.Join(src, "same.txt"), []byte("same\n"), 0644)
+		require.NoError(t, err)
+		err = os.WriteFile(filepath.Join(dst, "same.txt"), []byte("same\n"), 0644)
+		require.NoError(t, err)
+
+		cfg := SyncConfig{Mode: "copy", Files: []string{"same.txt"}}
+		_, err = SyncDirectionFiles(cfg, src, dst, Pull, false)
+		require.NoError(t, err)
+	})
+
+		t.Run("pull succeeds when source is newer and dst unchanged", func(t *testing.T) {
+			tmp := t.TempDir()
+			src := filepath.Join(tmp, "src")
+			dst := filepath.Join(tmp, "dst")
+			os.MkdirAll(src, 0755)
+			os.MkdirAll(dst, 0755)
+
+			// Write dst FIRST (older), then src (newer) — src must be strictly newer.
+			f, err := os.Create(filepath.Join(dst, "newer.txt"))
+			require.NoError(t, err)
+			f.WriteString("older")
+			f.Close()
+			dstInfo, _ := os.Stat(filepath.Join(dst, "newer.txt"))
+
+			time.Sleep(2100 * time.Millisecond) // ensure filesystem time advances
+			f, err = os.Create(filepath.Join(src, "newer.txt"))
+			require.NoError(t, err)
+			f.WriteString("newer")
+			f.Close()
+			srcInfo, _ := os.Stat(filepath.Join(src, "newer.txt"))
+
+			// Assert src is strictly newer so the test is meaningful.
+			assert.True(t, srcInfo.ModTime().After(dstInfo.ModTime()),
+				"src must be newer than dst for this test; got src=%v dst=%v",
+				srcInfo.ModTime(), dstInfo.ModTime())
+
+			cfg := SyncConfig{Mode: "copy", Files: []string{"newer.txt"}}
+			_, err = SyncDirectionFiles(cfg, src, dst, Pull, false)
+			require.NoError(t, err) // dst was older than src; no conflict
+
+			data, err := os.ReadFile(filepath.Join(dst, "newer.txt"))
+			require.NoError(t, err)
+			assert.Equal(t, "newer", string(data))
+		})
+
+
+	t.Run("pull succeeds when dst does not exist", func(t *testing.T) {
+		tmp := t.TempDir()
+		src := filepath.Join(tmp, "src")
+		dst := filepath.Join(tmp, "dst")
+		os.MkdirAll(src, 0755)
+		os.MkdirAll(dst, 0755)
+
+		err := os.WriteFile(filepath.Join(src, "new.txt"), []byte("new content\n"), 0644)
+		require.NoError(t, err)
+
+		cfg := SyncConfig{Mode: "copy", Files: []string{"new.txt"}}
+		_, err = SyncDirectionFiles(cfg, src, dst, Pull, false)
+		require.NoError(t, err)
+	})
+
+		t.Run("pull detects conflict when only mtime differs but content same", func(t *testing.T) {
+			tmp := t.TempDir()
+			src := filepath.Join(tmp, "src")
+			dst := filepath.Join(tmp, "dst")
+			os.MkdirAll(src, 0755)
+			os.MkdirAll(dst, 0755)
+
+			// Write dst FIRST, then src — src is newer, content is the same (no conflict).
+			f, err := os.Create(filepath.Join(dst, "same.txt"))
+			require.NoError(t, err)
+			f.WriteString("same")
+			f.Close()
+
+			time.Sleep(2100 * time.Millisecond)
+			f, err = os.Create(filepath.Join(src, "same.txt"))
+			require.NoError(t, err)
+			f.WriteString("same")
+			f.Close()
+
+			cfg := SyncConfig{Mode: "copy", Files: []string{"same.txt"}}
+			_, err = SyncDirectionFiles(cfg, src, dst, Pull, false)
+			require.NoError(t, err) // same content, no conflict
+		})
+
+}
+
+func TestConflictError(t *testing.T) {
+	err := &ConflictError{Files: []string{"a.txt", "b.txt"}}
+	assert.Contains(t, err.Error(), "sync conflict")
+	assert.Contains(t, err.Error(), "a.txt")
+	assert.Contains(t, err.Error(), "b.txt")
+}
+
+func TestFileHash(t *testing.T) {
+	tmp := t.TempDir()
+	f1 := filepath.Join(tmp, "file1.txt")
+	f2 := filepath.Join(tmp, "file2.txt")
+	err := os.WriteFile(f1, []byte("hello"), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(f2, []byte("hello"), 0644)
+	require.NoError(t, err)
+
+	h1, err := fileHash(f1)
+	require.NoError(t, err)
+	h2, err := fileHash(f2)
+	require.NoError(t, err)
+	assert.Equal(t, h1, h2)
+
+	h3, err := fileHash(filepath.Join(tmp, "missing.txt"))
+	assert.Error(t, err)
+	assert.Nil(t, h3)
+}
+
+func TestBytesEqual(t *testing.T) {
+	assert.True(t, bytesEqual([]byte("hello"), []byte("hello")))
+	assert.False(t, bytesEqual([]byte("hello"), []byte("world")))
+	assert.False(t, bytesEqual([]byte("hello"), []byte("hell")))
+	assert.False(t, bytesEqual([]byte{}, []byte("x")))
+}
+
+func TestAbs(t *testing.T) {
+	assert.Equal(t, time.Duration(5), abs(time.Duration(5)))
+	assert.Equal(t, time.Duration(5), abs(time.Duration(-5)))
+}
+
+func TestLoadSyncConfigForPath(t *testing.T) {
+	t.Run("missing file returns error", func(t *testing.T) {
+		tmp := t.TempDir()
+		_, err := loadSyncConfigForPath(filepath.Join(tmp, "notexist.yaml"), "symlink")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no .git-ctx-sync.yaml")
+	})
+
+	t.Run("valid file parsed correctly", func(t *testing.T) {
+		tmp := t.TempDir()
+		path := filepath.Join(tmp, ".git-ctx-sync.yaml")
+		err := os.WriteFile(path, []byte("mode: copy\nfiles:\n  - .env\n"), 0644)
+		require.NoError(t, err)
+
+		cfg, err := loadSyncConfigForPath(path, "symlink")
+		require.NoError(t, err)
+		assert.Equal(t, "copy", cfg.Mode)
+	})
+}
+
+func TestSyncDirectionFiles_Symlink(t *testing.T) {
+	t.Run("push creates symlinks", func(t *testing.T) {
+		tmp := t.TempDir()
+		src := filepath.Join(tmp, "src")
+		dst := filepath.Join(tmp, "dst")
+		os.MkdirAll(src, 0755)
+		os.MkdirAll(dst, 0755)
+
+		err := os.WriteFile(filepath.Join(src, "linked.txt"), []byte("content\n"), 0644)
+		require.NoError(t, err)
+
+		cfg := SyncConfig{Mode: "symlink", Files: []string{"linked.txt"}}
+		_, err = SyncDirectionFiles(cfg, src, dst, Push, false)
+		require.NoError(t, err)
+
+		link := filepath.Join(dst, "linked.txt")
+		info, err := os.Lstat(link)
+		require.NoError(t, err)
+		assert.True(t, info.Mode()&os.ModeSymlink != 0)
+	})
+}
+
+func assertEmpty(t *testing.T, s []string) {
+	t.Helper()
+	if len(s) != 0 {
+		t.Errorf("expected empty slice, got %d items", len(s))
+	}
 }


### PR DESCRIPTION
## Summary

Implements issue #14 — worktree bidirectional sync and watch mode:

- **`git ctx worktree push <path>`** — push files from the primary worktree to a specific worktree (same as `sync` but explicit direction)
- **`git ctx worktree pull <path>`** — pull files from a worktree back to the primary worktree, with **conflict detection** (returns an error listing conflicting files if the same file was modified in both worktrees since the last sync)
- **`git ctx worktree watch [path]`** — daemon that continuously watches configured sync files for changes and re-syncs automatically using `fsnotify`

## Technical notes

- Conflict detection uses mtime + content hash: if the destination was modified at or after the source file (within a 1-second tolerance), both hashes are compared; a mismatch triggers a `ConflictError` instead of an overwrite
- Watch mode debounces events (default 500ms) and deduplicates rapid writes to the same file
- `--copy` flag is supported on all three new commands

## Test plan

- [x] All new unit tests pass (`go test ./...`)
- [x] Conflict detection: pull returns error when both worktrees modified a file differently
- [x] Conflict detection: pull succeeds when only source is newer (destination unchanged)
- [x] Conflict detection: pull succeeds when destination is missing
- [x] Push: always overwrites without conflict check (expected behavior)

Fixes #14