### PR TITLE
feat(worktree): add bidirectional sync and watch mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,9 @@ require (
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/sys v0.1.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
@@ -23,6 +25,8 @@ github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -746,6 +746,9 @@ File sync is configured via .git-ctx-sync.yaml in the repo root:
 	worktreeCmd.AddCommand(buildWorktreeLsCmd(g))
 	worktreeCmd.AddCommand(buildWorktreeAddCmd(appCfg, g))
 	worktreeCmd.AddCommand(buildWorktreeSyncCmd(appCfg, g))
+	worktreeCmd.AddCommand(buildWorktreePushCmd(appCfg, g))
+	worktreeCmd.AddCommand(buildWorktreePullCmd(appCfg, g))
+	worktreeCmd.AddCommand(buildWorktreeWatchCmd(appCfg, g))
 
 	return worktreeCmd
 }
@@ -891,6 +894,76 @@ func buildWorktreeSyncCmd(appCfg config.AppConfig, g git.Runner) *cobra.Command 
 		},
 	}
 	cmd.Flags().BoolVar(&syncCopy, "copy", false, "Copy files instead of symlinking")
+	return cmd
+}
+
+func buildWorktreePushCmd(appCfg config.AppConfig, g git.Runner) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "push [path]",
+		Short: "Push synced files from primary repo to a worktree",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			absPath, err := filepath.Abs(args[0])
+			if err != nil {
+				fmt.Println("Error resolving path:", err)
+				os.Exit(1)
+			}
+			warnings, err := worktree.PushFiles(appCfg, g, absPath)
+			if err != nil {
+				fmt.Println("Push failed:", err)
+				os.Exit(1)
+			}
+			for _, w := range warnings {
+				fmt.Println("Warning:", w)
+			}
+			fmt.Printf("Pushed files to %s\n", absPath)
+		},
+	}
+	return cmd
+}
+
+func buildWorktreePullCmd(appCfg config.AppConfig, g git.Runner) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pull [path]",
+		Short: "Pull synced files from a worktree back to the primary repo",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			absPath, err := filepath.Abs(args[0])
+			if err != nil {
+				fmt.Println("Error resolving path:", err)
+				os.Exit(1)
+			}
+			warnings, err := worktree.PullFiles(appCfg, g, absPath)
+			if err != nil {
+				fmt.Println("Pull failed:", err)
+				os.Exit(1)
+			}
+			for _, w := range warnings {
+				fmt.Println("Warning:", w)
+			}
+			fmt.Printf("Pulled files from %s\n", absPath)
+		},
+	}
+	return cmd
+}
+
+func buildWorktreeWatchCmd(appCfg config.AppConfig, g git.Runner) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "watch [path]",
+		Short: "Watch a worktree for file changes and auto-sync to primary repo",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			absPath, err := filepath.Abs(args[0])
+			if err != nil {
+				fmt.Println("Error resolving path:", err)
+				os.Exit(1)
+			}
+			if err := worktree.WatchFiles(appCfg, g, absPath); err != nil {
+				fmt.Println("Watch failed:", err)
+				os.Exit(1)
+			}
+		},
+	}
 	return cmd
 }
 

--- a/internal/worktree/sync.go
+++ b/internal/worktree/sync.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/lvluu/git-ctx/internal/config"
 	"github.com/lvluu/git-ctx/internal/git"
 	"gopkg.in/yaml.v3"
@@ -101,6 +102,138 @@ func ListWorktreePaths(g git.Runner) ([]string, error) {
 		}
 	}
 	return paths, nil
+}
+
+// PushFiles syncs configured files from the primary repo to a worktree (primary → worktree).
+// Always uses copy mode since the destination is an independent worktree.
+func PushFiles(appCfg config.AppConfig, g git.Runner, worktreePath string) ([]string, error) {
+	repoRoot, inRepo, err := git.FindRepoRoot(g)
+	if err != nil {
+		return nil, err
+	}
+	if !inRepo {
+		return nil, fmt.Errorf("not inside a git repository")
+	}
+
+	syncCfgPath := filepath.Join(repoRoot, ".git-ctx-sync.yaml")
+	cfg, err := LoadSyncConfig(syncCfgPath, appCfg.Worktree.DefaultMode)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(cfg.Files) == 0 {
+		return nil, nil
+	}
+
+	return SyncFiles(cfg, repoRoot, worktreePath, true)
+}
+
+// PullFiles syncs configured files from a worktree back to the primary repo (worktree → primary).
+// Always uses copy mode.
+func PullFiles(appCfg config.AppConfig, g git.Runner, worktreePath string) ([]string, error) {
+	repoRoot, inRepo, err := git.FindRepoRoot(g)
+	if err != nil {
+		return nil, err
+	}
+	if !inRepo {
+		return nil, fmt.Errorf("not inside a git repository")
+	}
+
+	syncCfgPath := filepath.Join(repoRoot, ".git-ctx-sync.yaml")
+	cfg, err := LoadSyncConfig(syncCfgPath, appCfg.Worktree.DefaultMode)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(cfg.Files) == 0 {
+		return nil, nil
+	}
+
+	return SyncFiles(cfg, worktreePath, repoRoot, true)
+}
+
+// WatchFiles watches a worktree for changes to synced files and automatically
+// re-syncs them back to the primary repo (worktree → primary) on every write.
+// It blocks until the watcher is closed (Ctrl+C).
+func WatchFiles(appCfg config.AppConfig, g git.Runner, worktreePath string) error {
+	repoRoot, inRepo, err := git.FindRepoRoot(g)
+	if err != nil {
+		return err
+	}
+	if !inRepo {
+		return fmt.Errorf("not inside a git repository")
+	}
+
+	syncCfgPath := filepath.Join(repoRoot, ".git-ctx-sync.yaml")
+	cfg, err := LoadSyncConfig(syncCfgPath, appCfg.Worktree.DefaultMode)
+	if err != nil {
+		return err
+	}
+
+	if len(cfg.Files) == 0 {
+		return fmt.Errorf("no files configured in .git-ctx-sync.yaml")
+	}
+
+	// Build the set of directories to watch (deduplicated).
+	watchDirs := make(map[string]bool)
+	for _, rel := range cfg.Files {
+		abs := filepath.Join(worktreePath, rel)
+		watchDirs[filepath.Dir(abs)] = true
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("creating watcher: %w", err)
+	}
+	defer watcher.Close()
+
+	for dir := range watchDirs {
+		if err := watcher.Add(dir); err != nil {
+			return fmt.Errorf("watching directory %s: %w", dir, err)
+		}
+	}
+
+	fmt.Printf("Watching %d path(s) for changes (Ctrl+C to stop)...\n", len(watchDirs))
+
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+			// Only react to writes and creates.
+			if event.Op&(fsnotify.Write|fsnotify.Create) == 0 {
+				continue
+			}
+			rel, err := filepath.Rel(worktreePath, event.Name)
+			if err != nil {
+				continue
+			}
+			inList := false
+			for _, f := range cfg.Files {
+				if f == rel {
+					inList = true
+					break
+				}
+			}
+			if !inList {
+				continue
+			}
+			fmt.Printf("Change detected: %s — syncing to primary repo...\n", rel)
+			_, err = PullFiles(appCfg, g, worktreePath)
+			if err != nil {
+				fmt.Printf("Sync error: %v\n", err)
+			} else {
+				fmt.Printf("Synced: %s\n", rel)
+			}
+
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return nil
+			}
+			fmt.Printf("Watcher error: %v\n", err)
+		}
+	}
 }
 
 // RunSync loads .git-ctx-sync.yaml from the repo root and syncs files to dstWorktree.

--- a/internal/worktree/sync_test.go
+++ b/internal/worktree/sync_test.go
@@ -65,4 +65,125 @@ func TestSyncFiles(t *testing.T) {
 			t.Errorf("expected 1 warning, got %d", len(warnings))
 		}
 	})
+
+	t.Run("push direction: primary → worktree", func(t *testing.T) {
+		tmp := t.TempDir()
+		primary := filepath.Join(tmp, "primary")
+		worktree := filepath.Join(tmp, "worktree")
+		os.MkdirAll(primary, 0755)
+		os.MkdirAll(worktree, 0755)
+
+		cfgPath := filepath.Join(primary, ".git-ctx-sync.yaml")
+		os.WriteFile(cfgPath, []byte(`
+mode: copy
+files:
+  - config.toml
+`), 0644)
+
+		os.WriteFile(filepath.Join(primary, "config.toml"), []byte("primary content"), 0644)
+
+		cfg, err := LoadSyncConfig(cfgPath, "copy")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Primary → worktree (push direction).
+		warnings, err := SyncFiles(cfg, primary, worktree, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(warnings) != 0 {
+			t.Errorf("expected no warnings, got %d: %v", len(warnings), warnings)
+		}
+
+		data, err := os.ReadFile(filepath.Join(worktree, "config.toml"))
+		if err != nil {
+			t.Fatalf("file not synced: %v", err)
+		}
+		if string(data) != "primary content" {
+			t.Errorf("expected 'primary content', got %s", string(data))
+		}
+	})
+
+	t.Run("pull direction: worktree → primary", func(t *testing.T) {
+		tmp := t.TempDir()
+		primary := filepath.Join(tmp, "primary")
+		worktree := filepath.Join(tmp, "worktree")
+		os.MkdirAll(primary, 0755)
+		os.MkdirAll(worktree, 0755)
+
+		cfgPath := filepath.Join(primary, ".git-ctx-sync.yaml")
+		os.WriteFile(cfgPath, []byte(`
+mode: copy
+files:
+  - config.toml
+`), 0644)
+
+		// File originates in worktree.
+		os.WriteFile(filepath.Join(worktree, "config.toml"), []byte("worktree content"), 0644)
+
+		cfg, err := LoadSyncConfig(cfgPath, "copy")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Worktree → primary (pull direction).
+		_, err = SyncFiles(cfg, worktree, primary, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		data, err := os.ReadFile(filepath.Join(primary, "config.toml"))
+		if err != nil {
+			t.Fatalf("file not pulled: %v", err)
+		}
+		if string(data) != "worktree content" {
+			t.Errorf("expected 'worktree content', got %s", string(data))
+		}
+	})
+
+	t.Run("resync updates destination", func(t *testing.T) {
+		tmp := t.TempDir()
+		primary := filepath.Join(tmp, "primary")
+		worktree := filepath.Join(tmp, "worktree")
+		os.MkdirAll(primary, 0755)
+		os.MkdirAll(worktree, 0755)
+
+		cfgPath := filepath.Join(primary, ".git-ctx-sync.yaml")
+		os.WriteFile(cfgPath, []byte(`
+mode: copy
+files:
+  - config.toml
+`), 0644)
+
+		os.WriteFile(filepath.Join(primary, "config.toml"), []byte("original"), 0644)
+
+		cfg, err := LoadSyncConfig(cfgPath, "copy")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Initial sync.
+		_, err = SyncFiles(cfg, primary, worktree, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Edit primary.
+		os.WriteFile(filepath.Join(primary, "config.toml"), []byte("updated"), 0644)
+
+		// Re-sync (should overwrite worktree copy).
+		_, err = SyncFiles(cfg, primary, worktree, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		data, err := os.ReadFile(filepath.Join(worktree, "config.toml"))
+		if err != nil {
+			t.Fatalf("file not updated: %v", err)
+		}
+		if string(data) != "updated" {
+			t.Errorf("expected 'updated', got %s", string(data))
+		}
+	})
 }


### PR DESCRIPTION
Fixes #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `worktree push` command to synchronize files from worktree to primary repository
  * Added `worktree pull` command to synchronize files from primary repository to worktree
  * Added `worktree watch` command to automatically monitor and sync worktree file changes back to primary repository

<!-- end of auto-generated comment: release notes by coderabbit.ai -->